### PR TITLE
drop redundant constraints

### DIFF
--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -55,16 +55,16 @@ empty :: forall a. Vec D0 a
 empty = Vec []
 
 -- | Prepend a value to the front of a vector, creating a vector of size `Succ s`.
-cons :: forall s s' a. Nat s => Pos s' => Succ s s' => a -> Vec s a -> Vec s' a
+cons :: forall s s' a. Succ s s' => a -> Vec s a -> Vec s' a
 cons x (Vec xs) = Vec $ Array.cons x xs
 infixr 5 cons as +>
 
 -- | Append a value to the end of a vector, creating a vector of size `Succ s`.
-snoc :: forall s s' a. Nat s => Pos s' => Succ s s' => a -> Vec s a -> Vec s' a
+snoc :: forall s s' a. Succ s s' => a -> Vec s a -> Vec s' a
 snoc x (Vec xs) = Vec $ Array.snoc xs x
 
 -- | Get the head and the tail of a non-empty vector.
-uncons :: forall s1 s2 a. Pos s1 => Pred s1 s2 => Vec s1 a -> { head :: a, tail :: Vec s2 a }
+uncons :: forall s1 s2 a. Pred s1 s2 => Vec s1 a -> { head :: a, tail :: Vec s2 a }
 uncons (Vec v) = case unsafePartial $ fromJust $ Array.uncons v of
   { head: h, tail: t } -> { head: h, tail: Vec t }
 
@@ -102,30 +102,30 @@ toUnfoldable (Vec v) = Array.toUnfoldable v
 -- |     -- value == 3
 -- |     value = index myVector d4
 -- |     -- out of bounds so does not type check
-index :: forall i s a. Nat i => Nat s => Lt i s => Vec s a -> i -> a
+index :: forall i s a. Nat i => Lt i s => Vec s a -> i -> a
 index (Vec xs) i = unsafePartial $ Array.unsafeIndex xs $ toInt i
 infixl 8 index as !!
 
 -- | Concatenate two vectors together.
-concat :: forall s1 s2 s3 a. Nat s1 => Nat s2 => Add s1 s2 s3 => Vec s1 a -> Vec s2 a -> Vec s3 a
+concat :: forall s1 s2 s3 a. Add s1 s2 s3 => Vec s1 a -> Vec s2 a -> Vec s3 a
 concat (Vec xs1) (Vec xs2) = Vec $ Array.concat [xs1, xs2]
 
 -- | Update a vector with a given value inserted at a given index.
-updateAt :: forall i s a. Nat i => Nat s => Lt i s => i -> a -> Vec s a -> Vec s a
+updateAt :: forall i s a. Nat i => Lt i s => i -> a -> Vec s a -> Vec s a
 updateAt i v (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.updateAt (toInt i) v xs
 
 -- | Update a vector at a given index using a function.
-modifyAt :: forall i s a. Nat i => Nat s => Lt i s => i -> (a -> a) -> Vec s a -> Vec s a
+modifyAt :: forall i s a. Nat i => Lt i s => i -> (a -> a) -> Vec s a -> Vec s a
 modifyAt i f (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.modifyAt (toInt i) f xs
 
 -- | Insert a value at a given index inside a vector, returning a vector
 -- | that is one element larger.
-insertAt :: forall i s1 s2 a. Nat i => Nat s1 => Nat s2 => Lt i s1 => Succ s1 s2 => i -> a -> Vec s1 a -> Vec s2 a
+insertAt :: forall i s1 s2 a. Nat i => Lt i s1 => Succ s1 s2 => i -> a -> Vec s1 a -> Vec s2 a
 insertAt i a (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.insertAt (toInt i) a xs
 
 -- | Remove an element at a given index inside a vector, returning a vector
 -- | that is one element smaller.
-deleteAt :: forall i s1 s2 a. Nat i => Pos s1 => Nat s2 => Lt i s1 => Pred s1 s2 => i -> Vec s1 a -> Vec s2 a
+deleteAt :: forall i s1 s2 a. Nat i => Lt i s1 => Pred s1 s2 => i -> Vec s1 a -> Vec s2 a
 deleteAt i (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.deleteAt (toInt i) xs
 
 -- | Get the head of a non-empty vector.
@@ -137,38 +137,38 @@ last :: forall s a. Pos s => Vec s a -> a
 last (Vec xs) = unsafePartial $ fromJust $ Array.last xs
 
 -- | Get the tail of a non-empty vector.
-tail :: forall s1 s2 a. Pos s1 => Nat s2 => Pred s1 s2 => Vec s1 a -> Vec s2 a
+tail :: forall s1 s2 a. Pred s1 s2 => Vec s1 a -> Vec s2 a
 tail (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.tail xs
 
 -- | Get all but the last element of a non-empty vector.
-init :: forall s1 s2 a. Pos s1 =>Nat s2 => Pred s1 s2 => Vec s1 a -> Vec s2 a
+init :: forall s1 s2 a. Pred s1 s2 => Vec s1 a -> Vec s2 a
 init (Vec xs) = Vec $ unsafePartial $ fromJust $ Array.init xs
 
 -- | Insert an element into a sorted vector.
-insert :: forall s1 s2 a. Nat s1 => Succ s1 s2 => Ord a => a -> Vec s1 a -> Vec s2 a
+insert :: forall s1 s2 a. Succ s1 s2 => Ord a => a -> Vec s1 a -> Vec s2 a
 insert a (Vec v) = Vec $ Array.insert a v
 
 -- | Insert an element into a sorted vector using an ordering function.
-insertBy :: forall s1 s2 a. Nat s1 => Succ s1 s2 => (a -> a -> Ordering) -> a -> Vec s1 a -> Vec s2 a
+insertBy :: forall s1 s2 a. Succ s1 s2 => (a -> a -> Ordering) -> a -> Vec s1 a -> Vec s2 a
 insertBy f a (Vec v) = Vec $ Array.insertBy f a v
 
 -- | Get a sub-vector from index `i1` up to but not including index `i2`.
-slice :: forall i1 i2 s1 s2 a. Nat i1 => Nat i2 => Nat s1 => LtEq i1 s1 => LtEq i2 s1 => LtEq i1 i2 => Sub i2 i1 s2 => i1 -> i2 -> Vec s1 a -> Vec s2 a
+slice :: forall i1 i2 s1 s2 a. Nat i1 => Nat i2 => LtEq i1 s1 => LtEq i2 s1 => LtEq i1 i2 => Sub i2 i1 s2 => i1 -> i2 -> Vec s1 a -> Vec s2 a
 slice i1 i2 (Vec xs) = Vec $ Array.slice (toInt i1) (toInt i2) xs
 
 -- | Get the first `c` elements from a vector.
-take :: forall c s a. Nat c => Nat s => LtEq c s => c -> Vec s a -> Vec c a
+take :: forall c s a. Nat c => LtEq c s => c -> Vec s a -> Vec c a
 take c (Vec xs) = Vec $ Array.take (toInt c) xs
 
 -- | Drop the first `c` elements from a vector.
-drop :: forall c s1 s2 a. Nat c => Nat s1 => LtEq c s1 => Sub s1 c s2 => c -> Vec s1 a -> Vec s2 a
+drop :: forall c s1 s2 a. Nat c => LtEq c s1 => Sub s1 c s2 => c -> Vec s1 a -> Vec s2 a
 drop c (Vec xs) = Vec $ Array.drop (toInt c) xs
 
 -- | Zip two vectors together into a vector of tuples.
 -- |
 -- | The new vector will be the size of the smallest input vector, and
 -- | superfluous elements from the other will be discarded.
-zip :: forall s1 s2 s3 a b. Nat s1 => Nat s2 => Min s1 s2 s3 => Vec s1 a -> Vec s2 b -> Vec s3 (Tuple a b)
+zip :: forall s1 s2 s3 a b. Min s1 s2 s3 => Vec s1 a -> Vec s2 b -> Vec s3 (Tuple a b)
 zip (Vec v1) (Vec v2) = Vec $ Array.zip v1 v2
 
 -- | Zip two vectors together using a combining function.


### PR DESCRIPTION
It seems to me that these signatures are easier to read without the noise of constraints that are already implied by others.