### PR TITLE
eliminate redundant function arguments

### DIFF
--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -73,8 +73,8 @@ singleton :: forall a. a -> Vec D1 a
 singleton x = x +> empty
 
 -- | Construct a vector of a given length containing the same element repeated.
-replicate :: forall s a. Nat s => s -> a -> Vec s a
-replicate s a = Vec $ Array.replicate (toInt s) a
+replicate :: forall s a. Nat s => a -> Vec s a
+replicate a = Vec $ Array.replicate (toInt (undefined :: s)) a
 
 -- | Get the length of a vector as an integer.
 length :: forall s a. Nat s => Vec s a -> Int
@@ -152,17 +152,17 @@ insert a (Vec v) = Vec $ Array.insert a v
 insertBy :: forall s1 s2 a. Nat s1 => Succ s1 s2 => (a -> a -> Ordering) -> a -> Vec s1 a -> Vec s2 a
 insertBy f a (Vec v) = Vec $ Array.insertBy f a v
 
--- | Get a sub-vector from index `i1` up to but not including index `i2`.
-slice :: forall i1 i2 s1 s2 a. Nat i1 => Nat i2 => Nat s1 => LtEq i1 s1 => LtEq i2 s1 => LtEq i1 i2 => Sub i2 i1 s2 => i1 -> i2 -> Vec s1 a -> Vec s2 a
-slice i1 i2 (Vec xs) = Vec $ Array.slice (toInt i1) (toInt i2) xs
+-- | Get a sub-vector from index `i`` up
+slice :: forall i1 i2 s1 s2 a. Nat i1 => Nat i2 => Nat s1 => LtEq i1 s1 => LtEq i2 s1 => LtEq i1 i2 => Sub i2 i1 s2 => i1 -> Vec s1 a -> Vec s2 a
+slice i1 (Vec xs) = Vec $ Array.slice (toInt i1) (toInt (undefined :: i2)) xs
 
--- | Get the first `c` elements from a vector.
-take :: forall c s a. Nat c => Nat s => LtEq c s => c -> Vec s a -> Vec c a
-take c (Vec xs) = Vec $ Array.take (toInt c) xs
+-- | Get the first elements from a vector.
+take :: forall c s a. Nat c => Nat s => LtEq c s => Vec s a -> Vec c a
+take (Vec xs) = Vec $ Array.take (toInt (undefined :: c)) xs
 
--- | Drop the first `c` elements from a vector.
-drop :: forall c s1 s2 a. Nat c => Nat s1 => LtEq c s1 => Sub s1 c s2 => c -> Vec s1 a -> Vec s2 a
-drop c (Vec xs) = Vec $ Array.drop (toInt c) xs
+-- | Drop the first elements from a vector.
+drop :: forall c s1 s2 a. Nat c => Nat s1 => LtEq c s1 => Sub s1 c s2 => Vec s1 a -> Vec s2 a
+drop (Vec xs) = Vec $ Array.drop (toInt (undefined :: c)) xs
 
 -- | Zip two vectors together into a vector of tuples.
 -- |
@@ -202,7 +202,7 @@ instance applyVec :: Nat s => Apply (Vec s) where
   apply (Vec a) (Vec b) = Vec $ apply a b
 
 instance applicativeVec :: Nat s => Applicative (Vec s) where
-  pure a = replicate (undefined :: s) a
+  pure = replicate
 
 instance foldableVec :: Nat s => Foldable (Vec s) where
   foldMap f (Vec xs) = foldMap f xs

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,9 +4,9 @@ import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Data.Traversable (sequence)
-import Data.Typelevel.Num (toInt, d6, d3, d9, d2, D9)
+import Data.Typelevel.Num (toInt, d3, D1, D2, D3, D9)
 import Data.Vec (Vec, slice, tail, drop, take, lengthT, concat, replicate, (+>), empty)
-import Prelude (($), Unit, bind, pure, discard)
+import Prelude (($), Unit, pure, discard)
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Console (TESTOUTPUT)
@@ -15,9 +15,9 @@ import Test.Unit.Main (runTest)
 main :: forall e. Eff (console :: CONSOLE, testOutput :: TESTOUTPUT, avar :: AVAR | e) Unit
 main = runTest do
   suite "vec" do
-    let vec1 = replicate d2 1
-        vec2 = replicate d3 2
-        vec3 = replicate d9 3
+    let (vec1 :: Vec D2 Int) = replicate 1
+        (vec2 :: Vec D3 Int) = replicate 2
+        (vec3 :: Vec D9 Int) = replicate 3
     test "cons length" do
       equal 3 $ toInt $ lengthT $ 1 +> 2 +> 3 +> empty
     test "replicate length" do
@@ -25,13 +25,13 @@ main = runTest do
     test "concat length" do
       equal 5 $ toInt $ lengthT (concat vec1 vec2)
     test "take length" do
-      equal 2 $ toInt $ lengthT (take d2 vec2)
+      equal 2 $ toInt $ lengthT (take vec2 :: Vec D2 Int)
     test "drop length" do
-      equal 1 $ toInt $ lengthT (drop d2 vec2)
+      equal 1 $ toInt $ lengthT (drop vec2 :: Vec D1 Int)
     test "tail length" do
       equal 1 $ toInt $ lengthT (tail vec1)
     test "slice length" do
-      equal 3 $ toInt $ lengthT (slice d3 d6 vec3)
+      equal 3 $ toInt $ lengthT (slice d3 vec3 :: Vec D3 Int)
     test "pure replicates" do
       let vec3' = pure 3 :: Vec D9 Int
       equal vec3 vec3'


### PR DESCRIPTION
Several functions took redundant arguments containing information that could already be inferred from type signatures.