### PR TITLE
Distributive instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "purescript-foldable-traversable": "^3.0.0",
     "purescript-maybe": "^3.0.0",
     "purescript-arrays": "^4.0.1",
-    "purescript-unfoldable": "^3.0.0"
+    "purescript-unfoldable": "^3.0.0",
+    "purescript-distributive": "^3.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -40,6 +40,7 @@ module Data.Vec
 
 import Prelude
 import Data.Array as Array
+import Data.Distributive (class Distributive, collectDefault)
 import Data.Foldable (foldl, foldr, foldMap, class Foldable)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Traversable (traverse, sequence, class Traversable)
@@ -237,6 +238,14 @@ instance foldableVec :: Nat s => Foldable (Vec s) where
 instance traversableVec :: Nat s => Traversable (Vec s) where
   traverse f (Vec xs) = Vec <$> traverse f xs
   sequence (Vec xs) = Vec <$> sequence xs
+
+instance distributiveVec :: Pos s => Distributive (Vec s) where
+  collect = collectDefault
+  distribute vs =
+    let as = map toArray vs
+        len = toInt (undefined :: s)
+        indexes = Array.range 0 (len - 1)
+    in  Vec $ flap (unsafePartial Array.unsafeIndex <$> as) <$> indexes
 
 instance eqVec :: (Nat s, Eq a) => Eq (Vec s a) where
   eq (Vec v1) (Vec v2) = v1 == v2

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -239,12 +239,12 @@ instance traversableVec :: Nat s => Traversable (Vec s) where
   traverse f (Vec xs) = Vec <$> traverse f xs
   sequence (Vec xs) = Vec <$> sequence xs
 
-instance distributiveVec :: Pos s => Distributive (Vec s) where
+instance distributiveVec :: Nat s => Distributive (Vec s) where
   collect = collectDefault
   distribute vs =
     let as = map toArray vs
         len = toInt (undefined :: s)
-        indexes = Array.range 0 (len - 1)
+        indexes = if len == 0 then [] else Array.range 0 (len - 1)
     in  Vec $ flap (unsafePartial Array.unsafeIndex <$> as) <$> indexes
 
 instance eqVec :: (Nat s, Eq a) => Eq (Vec s a) where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
+import Data.Distributive (distribute)
 import Data.Maybe (fromJust)
 import Data.Traversable (sequence)
 import Data.Typelevel.Num (D1, D2, D3, D4, D9, d2, d3, d6, toInt)
@@ -58,3 +59,17 @@ main = runTest do
                      , 2 +> 3 +> empty
                      ]
       equal expected $ sequence vecOfArrays
+    test "distributive" do
+      let vecs1 = (1 +> 2 +> empty)
+               +> (3 +> 4 +> empty)
+               +> (5 +> 6 +> empty)
+               +> empty
+
+          vecs2 =  (1 +> 3 +> 5 +> empty)
+                +> (2 +> 4 +> 6 +> empty)
+                +> empty
+
+      equal vecs2 $ distribute vecs1
+      equal vecs1 $ distribute vecs2
+      equal vecs1 $ distribute $ distribute vecs1
+      equal vecs2 $ distribute $ distribute vecs2


### PR DESCRIPTION
Tests its use as matrix transposition.

This facilitates doing some simple things with type-safe matrices composed of `Vec`s of `Vec`s.