### PR TITLE
Add Semigroup and Monoid instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /output/
 /.psci*
 /src/.webpack.js
+.psc*

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /output/
 /.psci*
 /src/.webpack.js
-.psc*
+/.psc*

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -111,10 +111,10 @@ replicate = const replicate'
 replicate' :: forall s a. Nat s => a -> Vec s a
 replicate' a = Vec $ Array.replicate (toInt (undefined :: s)) a
 
-range' ∷ ∀s. Nat s => Int → Vec s Int
+range' ∷ forall s. Nat s => Int -> Vec s Int
 range' i = fill (_ + i)
 
-range ∷ ∀s. Nat s => Int → s -> Vec s Int
+range ∷ forall s. Nat s => Int -> s -> Vec s Int
 range i _ = range' i
 
 -- | Convert an array to a vector.
@@ -237,7 +237,7 @@ zip (Vec v1) (Vec v2) = Vec $ Array.zip v1 v2
 -- |
 -- | The new vector will be the size of the smallest input vector, and
 -- | superfluous elements from the other will be discarded.
-zipWith :: forall s1 s2 s3 a b c. Nat s1 => Nat s2 => Min s1 s2 s3 => (a -> b -> c) -> Vec s1 a -> Vec s2 b -> Vec s3 c
+zipWith :: forall s1 s2 s3 a b c. Min s1 s2 s3 => (a -> b -> c) -> Vec s1 a -> Vec s2 b -> Vec s3 c
 zipWith f (Vec v1) (Vec v2) = Vec $ Array.zipWith f v1 v2
 
 -- | Zip two vectors with equal length together using a combining function.

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -47,6 +47,7 @@ module Data.Vec
   ) where
 
 import Prelude
+import Control.Apply (lift2)
 import Data.Array as Array
 import Data.Distributive (class Distributive, collectDefault)
 import Data.Foldable (foldl, foldr, foldMap, class Foldable, sum)
@@ -293,13 +294,15 @@ instance showVec :: (Nat s, Show a) => Show (Vec s a) where
   show (Vec v) = show v
 
 instance semiringVec :: (Semiring a, Nat s) => Semiring (Vec s a) where
-  add v1 v2 = zipWithE add v1 v2
+  add = lift2 add
   zero = pure zero
-  mul v1 v2 = zipWithE mul v1 v2
+  mul = lift2 mul
   one = pure one
 
 instance ringVec :: (Ring a, Nat s) => Ring (Vec s a) where
-  sub v1 v2 = zipWithE sub v1 v2
+  sub = lift2 sub
+
+instance commutativeRingVec :: (CommutativeRing a, Nat s) => CommutativeRing (Vec s a)
 
 dotProduct :: ∀s a. Nat s => Semiring a => Vec s a -> Vec s a -> a
 dotProduct a b = sum $ zipWithE (*) a b

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -304,5 +304,11 @@ instance ringVec :: (Ring a, Nat s) => Ring (Vec s a) where
 
 instance commutativeRingVec :: (CommutativeRing a, Nat s) => CommutativeRing (Vec s a)
 
+instance semigroupVec :: (Semigroup a, Nat s) => Semigroup (Vec s a) where
+  append = lift2 append
+
+instance monoidVec :: (Monoid a, Nat s) => Monoid (Vec s a) where
+  mempty = pure mempty
+
 dotProduct :: ∀s a. Nat s => Semiring a => Vec s a -> Vec s a -> a
 dotProduct a b = sum $ zipWithE (*) a b

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -264,7 +264,7 @@ instance functorVec :: Nat s => Functor (Vec s) where
   map f (Vec xs) = Vec $ map f xs
 
 instance applyVec :: Nat s => Apply (Vec s) where
-  apply (Vec a) (Vec b) = Vec $ apply a b
+  apply a b = zipWithE ($) a b
 
 instance applicativeVec :: Nat s => Applicative (Vec s) where
   pure a = replicate' a

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -291,7 +291,7 @@ instance eqVec :: (Nat s, Eq a) => Eq (Vec s a) where
   eq (Vec v1) (Vec v2) = v1 == v2
 
 instance showVec :: (Nat s, Show a) => Show (Vec s a) where
-  show (Vec v) = show v
+  show (Vec v) = "(Vec " <> show v <> ")"
 
 instance semiringVec :: (Semiring a, Nat s) => Semiring (Vec s a) where
   add = lift2 add

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,7 +9,6 @@ import Data.Typelevel.Num (D1, D2, D3, D4, D9, d2, d3, d6, toInt)
 import Data.Vec (Vec, concat, dotProduct, drop, drop', empty, fill, fromArray, length, lengthT, range, range', replicate, replicate', slice, slice', tail, take, take', (+>))
 import Data.Vec as Vec
 import Partial.Unsafe (unsafePartial)
-import Prelude (Unit, discard, pure, ($), (+))
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Main (runTest)
@@ -50,6 +49,24 @@ main = runTest do
     test "slice length" do
       equal 3 $ length $ slice d3 d6 vec3
       equal 3 $ toInt $ (lengthT (slice' d3 vec3) :: D3)
+
+    let f = (+) 1 +> (+) 3 +> empty
+        g = (*) 3 +> (*) 2 +> empty
+        h = 5 +> 6 +> empty
+        x = 1 +> 3 +> empty
+
+        f' a = a + 1
+        x' = 2
+    test "apply law: Associative composition" do
+      equal ((<<<) <$> f <*> g <*> h) (f <*> (g <*> h))
+    test "applicative law: Identity" do
+      equal (pure identity <*> x) x
+    test "applicative law: Composition" do
+      equal (pure (<<<) <*> f <*> g <*> h) (f <*> (g <*> h))
+    test "applicative law: Homomorphism" do
+      equal (pure f' <*> pure x') (pure (f' x') :: Vec D2 Int)
+    test "applicative law: Interchange" do
+      equal (f <*> (pure x')) (pure (_ $ x') <*> f)
     test "pure replicates" do
       let vec3' = pure 3 :: Vec D9 Int
       equal vec3 vec3'

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -117,6 +117,13 @@ main = runTest do
       let v1 = Vec.vec3 1 2 3
           v2 = Vec.vec3 4 5 6
       equal (v1 * v2) (v2 * v1)
+    test "semigroup and monoid" do
+      let v1 = Vec.vec3 "he" "," "wor"
+          v2 = Vec.vec3 "llo" " " "ld"
+          v3 = Vec.vec3 " a" " b" " c"
+      equal ((v1 <> v2) <> v3) (v1 <> (v2 <> v3))
+      equal (v1 <> mempty) v1
+      equal (mempty <> v1) v1
     test "dotProduct" do
       equal 0 $ dotProduct (Vec.vec3 1 0 0) (Vec.vec3 0 1 0)
       equal 32 $ dotProduct (Vec.vec3 1 2 3) (Vec.vec3 4 5 6)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -50,10 +50,10 @@ main = runTest do
       equal 3 $ length $ slice d3 d6 vec3
       equal 3 $ toInt $ (lengthT (slice' d3 vec3) :: D3)
 
-    let f = (+) 1 +> (+) 3 +> empty
-        g = (*) 3 +> (*) 2 +> empty
-        h = 5 +> 6 +> empty
-        x = 1 +> 3 +> empty
+    let f = Vec.vec2 (_ + 1) (_ + 3)
+        g = Vec.vec2 (_ * 3) (_ * 2)
+        h = Vec.vec2 5 6
+        x = Vec.vec2 1 3
 
         f' a = a + 1
         x' = 2
@@ -113,6 +113,10 @@ main = runTest do
       let v1 = Vec.vec3 1 2 3
       equal (v1 - v1) zero
       equal ((zero - v1) + v1) zero
+    test "commutative ring" do
+      let v1 = Vec.vec3 1 2 3
+          v2 = Vec.vec3 4 5 6
+      equal (v1 * v2) (v2 * v1)
     test "dotProduct" do
       equal 0 $ dotProduct (Vec.vec3 1 0 0) (Vec.vec3 0 1 0)
       equal 32 $ dotProduct (Vec.vec3 1 2 3) (Vec.vec3 4 5 6)


### PR DESCRIPTION
These work by individually appending the elements of the first vector to the corresponding element in the other vector, leaving the size the same. Example: `vec3 "a" "b" "c" <> vec3 "d" "e" "f"` is `vec3 "ad" "be" "cf"`