### PR TITLE
withIndex instances

### DIFF
--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -47,10 +47,12 @@ module Data.Vec
   ) where
 
 import Prelude
+
 import Control.Apply (lift2)
 import Data.Array as Array
 import Data.Distributive (class Distributive, collectDefault, distribute)
 import Data.Foldable (foldl, foldr, foldMap, class Foldable, sum)
+import Data.FoldableWithIndex (class FoldableWithIndex, foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Traversable (traverse, sequence, class Traversable)
@@ -285,7 +287,7 @@ instance bindVec :: Nat s => Bind (Vec s) where
 
 instance monadVec :: Nat s => Monad (Vec s)
 
-instance foldableVec :: Nat s => Foldable (Vec s) where
+instance foldableVec :: Foldable (Vec s) where
   foldMap f (Vec xs) = foldMap f xs
   foldr f i (Vec xs) = foldr f i xs
   foldl f i (Vec xs) = foldl f i xs
@@ -326,7 +328,12 @@ instance monoidVec :: (Monoid a, Nat s) => Monoid (Vec s a) where
   mempty = pure mempty
 
 instance functorWithIndex :: FunctorWithIndex Int (Vec s) where
-  mapWithIndex f (Vec xs) = Vec $ Array.mapWithIndex f xs 
+  mapWithIndex f (Vec xs) = Vec $ Array.mapWithIndex f xs
+
+instance foldableWithIndex :: FoldableWithIndex Int (Vec s) where
+  foldrWithIndex f z (Vec xs) = foldrWithIndex f z xs
+  foldlWithIndex f z (Vec xs) = foldlWithIndex f z xs
+  foldMapWithIndex f (Vec xs) = foldMapWithIndex f xs
 
 dotProduct :: forall s a. Nat s => Semiring a => Vec s a -> Vec s a -> a
 dotProduct a b = sum $ zipWithE (*) a b

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -56,6 +56,7 @@ import Data.FoldableWithIndex (class FoldableWithIndex, foldMapWithIndex, foldlW
 import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Traversable (traverse, sequence, class Traversable)
+import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Data.Tuple (Tuple(Tuple))
 import Data.Typelevel.Num (class Min, class Sub, class LtEq, class Pred, class Lt)
 import Data.Typelevel.Num.Ops (class Add, class Succ)
@@ -292,7 +293,7 @@ instance foldableVec :: Foldable (Vec s) where
   foldr f i (Vec xs) = foldr f i xs
   foldl f i (Vec xs) = foldl f i xs
 
-instance traversableVec :: Nat s => Traversable (Vec s) where
+instance traversableVec :: Traversable (Vec s) where
   traverse f (Vec xs) = Vec <$> traverse f xs
   sequence (Vec xs) = Vec <$> sequence xs
 
@@ -334,6 +335,9 @@ instance foldableWithIndex :: FoldableWithIndex Int (Vec s) where
   foldrWithIndex f z (Vec xs) = foldrWithIndex f z xs
   foldlWithIndex f z (Vec xs) = foldlWithIndex f z xs
   foldMapWithIndex f (Vec xs) = foldMapWithIndex f xs
+
+instance traversableWithIndex :: TraversableWithIndex Int (Vec s) where
+  traverseWithIndex f (Vec xs) = Vec <$> traverseWithIndex f xs
 
 dotProduct :: forall s a. Nat s => Semiring a => Vec s a -> Vec s a -> a
 dotProduct a b = sum $ zipWithE (*) a b

--- a/src/Data/Vec.purs
+++ b/src/Data/Vec.purs
@@ -51,6 +51,7 @@ import Control.Apply (lift2)
 import Data.Array as Array
 import Data.Distributive (class Distributive, collectDefault, distribute)
 import Data.Foldable (foldl, foldr, foldMap, class Foldable, sum)
+import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Traversable (traverse, sequence, class Traversable)
 import Data.Tuple (Tuple(Tuple))
@@ -270,7 +271,7 @@ sortBy f (Vec v) = Vec $ Array.sortBy f v
 reverse :: forall s a. Nat s => Vec s a -> Vec s a
 reverse (Vec v) = Vec $ Array.reverse v
 
-instance functorVec :: Nat s => Functor (Vec s) where
+instance functorVec :: Functor (Vec s) where
   map f (Vec xs) = Vec $ map f xs
 
 instance applyVec :: Nat s => Apply (Vec s) where
@@ -323,6 +324,9 @@ instance semigroupVec :: (Semigroup a, Nat s) => Semigroup (Vec s a) where
 
 instance monoidVec :: (Monoid a, Nat s) => Monoid (Vec s a) where
   mempty = pure mempty
+
+instance functorWithIndex :: FunctorWithIndex Int (Vec s) where
+  mapWithIndex f (Vec xs) = Vec $ Array.mapWithIndex f xs 
 
 dotProduct :: forall s a. Nat s => Semiring a => Vec s a -> Vec s a -> a
 dotProduct a b = sum $ zipWithE (*) a b

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,10 @@
 module Test.Main where
 
 import Prelude
+
 import Data.Distributive (distribute)
+import Data.Foldable (foldMap, foldl, foldr)
+import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Maybe (fromJust)
 import Data.Traversable (sequence)
@@ -118,3 +121,13 @@ main = runTest do
           (mapWithIndex f <<< mapWithIndex g) vec == mapWithIndex (\i -> f i <<< g i) vec
     test "functor law: identity, composition" do
       liftEffect $ checkFunctor (Proxy2 :: Proxy2 (Vec D9))
+    suite "foldableWithIndex" do
+      test "foldr compatible" do
+        quickCheck \(f :: A -> B -> B) (b :: B) (fa :: Vec D9 A) ->
+          foldr f b fa == foldrWithIndex (const f) b fa
+      test "foldl compatible" do
+        quickCheck \(f :: B -> A -> B) (b :: B) (fa :: Vec D9 A) ->
+          foldl f b fa == foldlWithIndex (const f) b fa
+      test "foldMapWithIndex compatible" do
+        quickCheck \(f :: A -> B) (fa :: Vec D9 A) ->
+          foldMap f fa == foldMapWithIndex (const f) fa


### PR DESCRIPTION
Adds
- `FunctorWithIndex`
- `FoldableWithIndex`
- `TraversableWithIndex`

respectively its tests.

Note that some `Nat` constraints were removed from superclass implementations of the above instances. (e.g. `Functor` or `Foldable`)
They are not needed for the instances and would bubble up into the new implementations. I guess they can be removed in some other cases, too.