### PR TITLE
Add installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 
 Idris style sized vectors using [purescript-typelevel](https://github.com/bodil/purescript-typelevel).
 
-* [API docs on Pursuit](http://pursuit.purescript.org/packages/purescript-sized-vectors/)
+- [API docs on Pursuit](http://pursuit.purescript.org/packages/purescript-sized-vectors/)
+
+## Installation
+
+```bash
+bower install --save purescript-sized-vectors
+```
+
+or
+
+```
+spago install sized-vectors
+```
 
 ## Usage
 


### PR DESCRIPTION
This currently will still install `4.0.0` for `spago`.

I'm in the process of bringing in `5.0.0` into the latest package set. Turned out that `sized-matrices` depends on - guess what - `range'`. I'll see if I can make a PR there...