### PR TITLE
Update argonaut dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "purescript-typelevel": "^6.0.0",
     "purescript-distributive": "^4.0.0",
     "purescript-quickcheck": "^6.1.0",
-    "purescript-argonaut": "^6.0.0"
+    "purescript-argonaut": "^7.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates the Bower dependencies for this library.

Fortunately, this library builds with both versions of Argonaut without code changes, so it's not necessary to update anything for this to remain compatible with the next version of the package sets. Still, Bower users will need the new release to stay compatible.

Sorry for the hassle! Thanks!